### PR TITLE
Maximoramirez/eve 66 update invites to have status and type instead of all of it

### DIFF
--- a/prisma/migrations/20231012144822_invite_change/migration.sql
+++ b/prisma/migrations/20231012144822_invite_change/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - The values [HOST] on the enum `confirmationStatus` will be removed. If these variants are still used in the database, this will fail.
+  - Added the required column `isHost` to the `Guest` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "confirmationStatus_new" AS ENUM ('PENDING', 'ATTENDING', 'NOT_ATTENDING');
+ALTER TABLE "Guest" ALTER COLUMN "confirmationStatus" TYPE "confirmationStatus_new" USING ("confirmationStatus"::text::"confirmationStatus_new");
+ALTER TYPE "confirmationStatus" RENAME TO "confirmationStatus_old";
+ALTER TYPE "confirmationStatus_new" RENAME TO "confirmationStatus";
+DROP TYPE "confirmationStatus_old";
+COMMIT;
+
+-- DropForeignKey
+ALTER TABLE "Guest" DROP CONSTRAINT "Guest_eventId_fkey";
+
+-- AlterTable
+ALTER TABLE "Guest" ADD COLUMN     "isHost" BOOLEAN NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Guest" ADD CONSTRAINT "Guest_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Guest {
   user               User               @relation("Guests", fields: [userId], references: [id])
   event              Event              @relation(fields: [eventId], references: [id], onDelete: Cascade)
   confirmationStatus confirmationStatus
+  isHost             Boolean
 
   @@unique([userId, eventId])
 }
@@ -52,5 +53,4 @@ enum confirmationStatus {
   PENDING
   ATTENDING
   NOT_ATTENDING
-  HOST
 }

--- a/src/domains/event/input/inviteGuest.input.ts
+++ b/src/domains/event/input/inviteGuest.input.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsNumber } from 'class-validator';
+import {IsBoolean, IsNotEmpty, IsNumber} from 'class-validator';
 
 export class inviteGuestInput {
   @IsNotEmpty()
@@ -7,4 +7,7 @@ export class inviteGuestInput {
   @IsNotEmpty()
   @IsNumber()
   userId: number;
+  @IsNotEmpty()
+  @IsBoolean()
+  isHost: boolean;
 }

--- a/src/domains/event/repository/event.repository.interface.ts
+++ b/src/domains/event/repository/event.repository.interface.ts
@@ -26,6 +26,7 @@ export abstract class IEventRepository {
   abstract inviteGuest(
     eventId: number,
     invitedId: number,
+    isHost: boolean,
   ): Promise<GuestDto>;
 
   abstract answerInvite(

--- a/src/domains/event/repository/event.repository.ts
+++ b/src/domains/event/repository/event.repository.ts
@@ -23,7 +23,7 @@ export class EventRepository implements IEventRepository {
     return this.prisma.guest.count({
       where: {
         eventId: eventId,
-        confirmationStatus: { in: ['ATTENDING', 'HOST'] },
+        confirmationStatus: { in: ['ATTENDING'] },
       },
     });
   }
@@ -74,7 +74,7 @@ export class EventRepository implements IEventRepository {
       return this.prisma.guest.findUnique({
           where: {
               userId_eventId: {userId, eventId},
-              confirmationStatus: 'HOST',
+             isHost: true,
           },
       });
   }
@@ -91,7 +91,8 @@ export class EventRepository implements IEventRepository {
                 guests: {
                     create: {
                         userId: userId,
-                        confirmationStatus: 'HOST',
+                        confirmationStatus: 'ATTENDING',
+                        isHost: true,
                     },
                 },
             },
@@ -140,11 +141,12 @@ export class EventRepository implements IEventRepository {
         });
     }
 
-    async inviteGuest(eventId: number, invitedId: number): Promise<GuestDto> {
+    async inviteGuest(eventId: number, invitedId: number, isHost: boolean): Promise<GuestDto> {
         return this.prisma.guest.create({
             data: {
                 userId: invitedId,
                 eventId: eventId,
+                isHost: isHost,
                 confirmationStatus: 'PENDING',
             },
         });

--- a/src/domains/event/service/event.service.ts
+++ b/src/domains/event/service/event.service.ts
@@ -92,7 +92,7 @@ export class EventService implements IEventService {
       if (!this.checkEventDate(event.date)) throw new ForbiddenException("The event date has passed")
       else if (!this.checkEventDate(event.confirmationDeadline)) throw new ForbiddenException("The confirmation deadline has passed")
       try {
-        return await this.repository.inviteGuest(eventId, invitedId);
+        return await this.repository.inviteGuest(eventId, invitedId, input.isHost);
       } catch (error) {
         if (error instanceof PrismaClientKnownRequestError) {
           if (error.code === 'P2002') {

--- a/src/domains/event/service/event.service.ts
+++ b/src/domains/event/service/event.service.ts
@@ -88,6 +88,7 @@ export class EventService implements IEventService {
     const invitedId = input.userId;
     const hostGuest = await this.repository.getHostGuest(eventId, userId);
     const event = await this.repository.getEvent(eventId);
+    console.log(hostGuest);
     if (hostGuest != null || event.creatorId === userId) {
       if (!this.checkEventDate(event.date)) throw new ForbiddenException("The event date has passed")
       else if (!this.checkEventDate(event.confirmationDeadline)) throw new ForbiddenException("The confirmation deadline has passed")

--- a/src/domains/event/service/event.service.ts
+++ b/src/domains/event/service/event.service.ts
@@ -86,9 +86,8 @@ export class EventService implements IEventService {
   async inviteGuest(input: inviteGuestInput, userId: number) {
     const eventId = input.eventId;
     const invitedId = input.userId;
-    const hostGuest = await this.repository.getHostGuest(eventId, userId);
+    const hostGuest = await this.repository.getHostGuest(userId, eventId);
     const event = await this.repository.getEvent(eventId);
-    console.log(hostGuest);
     if (hostGuest != null || event.creatorId === userId) {
       if (!this.checkEventDate(event.date)) throw new ForbiddenException("The event date has passed")
       else if (!this.checkEventDate(event.confirmationDeadline)) throw new ForbiddenException("The confirmation deadline has passed")

--- a/test/event/unit/event.service.spec.ts
+++ b/test/event/unit/event.service.spec.ts
@@ -43,8 +43,16 @@ describe('EventService Unit Test', () => {
 	};
 	const inviteGuestInput : inviteGuestInput = {
 		eventId: 1,
-		userId: guestId
+		userId: guestId,
+        isHost: false
+
 	};
+
+    const hostInviteGuestInput: inviteGuestInput = {
+        eventId: 1,
+        userId: guestId,
+        isHost: true
+    }
 
 	it('Create event', async () => {
 		const event : Event = {
@@ -70,7 +78,7 @@ describe('EventService Unit Test', () => {
 				coordinates: input.coordinates,
 				date: input.date,
 				confirmationDeadline: input.confirmationDeadline,
-				confirmationStatus: 'HOST',
+				confirmationStatus: 'ATTENDING', //Changed from host to attending
                 id: 1,
 				guests: 1,
 			};
@@ -95,7 +103,7 @@ describe('EventService Unit Test', () => {
 				coordinates: input.coordinates,
 				date: input.date,
 				confirmationDeadline: input.confirmationDeadline,
-				confirmationStatus: 'HOST',
+				confirmationStatus: 'ATTENDING', //Changed from host to attending
                 id: 1,
 				guests: 1,
 			};
@@ -152,6 +160,7 @@ describe('EventService Unit Test', () => {
 				userId: guestId,
 				eventId: event.id,
 				confirmationStatus: 'PENDING',
+                isHost: false
 			});
 		})
 	})
@@ -171,22 +180,24 @@ describe('EventService Unit Test', () => {
 				userId: guestId,
 				eventId: event.id,
 				confirmationStatus: 'ATTENDING',
+                isHost: false
 			});
 		})
-		it('Guest answer HOST', async () => {
+		it('Guest was invited as host, answers ATTENDING', async () => {
 			const event = await eventService.createEvent(userId, input);
 			const answerInviteInput = {
 				eventId: event.id,
-				answer: confirmationStatus.HOST,
+				answer: confirmationStatus.ATTENDING,
 			}
-			await eventService.inviteGuest(inviteGuestInput, userId);
+			await eventService.inviteGuest(hostInviteGuestInput, userId);
 			const result = await eventService.answerInvite(answerInviteInput, guestId);
 
 			expect(result).toEqual({
 				id: guestId,
 				userId: guestId,
 				eventId: event.id,
-				confirmationStatus: 'HOST',
+				confirmationStatus: 'ATTENDING',
+                isHost: true
 			});
 		})
 		it('Guest answer PENDING', async () => {
@@ -203,6 +214,7 @@ describe('EventService Unit Test', () => {
 				userId: guestId,
 				eventId: event.id,
 				confirmationStatus: 'PENDING',
+                isHost: false
 			});
 		})
 		it('Guest answer NOT ATTENDING', async () => {
@@ -219,6 +231,7 @@ describe('EventService Unit Test', () => {
 				userId: guestId,
 				eventId: event.id,
 				confirmationStatus: 'NOT_ATTENDING',
+                isHost: false
 			});
 		})
 	})
@@ -226,19 +239,20 @@ describe('EventService Unit Test', () => {
 	describe('Get Invites By User', () => {
 		it("get host's invite", async () => {
 			const event = await eventService.createEvent(userId, input);
-			await eventService.inviteGuest(inviteGuestInput, userId);
+			await eventService.inviteGuest(hostInviteGuestInput, userId);
 			const result = await eventService.getInvitesByUser(userId);
 
 			expect(result).toEqual([{
 				id: userId,
 				userId: userId,
 				eventId: event.id,
-				confirmationStatus: 'HOST',
+				confirmationStatus: 'ATTENDING',
+                isHost: true
 			}]);
 		})
 		it("get host's invite", async () => {
 			const event = await eventService.createEvent(userId, input);
-			await eventService.inviteGuest(inviteGuestInput, userId);
+			await eventService.inviteGuest(hostInviteGuestInput, userId);
 			const result = await eventService.getInvitesByUser(guestId);
 
 			expect(result).toEqual([{
@@ -246,6 +260,7 @@ describe('EventService Unit Test', () => {
 				userId: guestId,
 				eventId: event.id,
 				confirmationStatus: 'PENDING',
+                isHost: true
 			}]);
 		})
 	})
@@ -253,19 +268,21 @@ describe('EventService Unit Test', () => {
 	describe('Get Guests By Event', () => {
 		it("get host's invite", async () => {
 			const event = await eventService.createEvent(userId, input);
-			await eventService.inviteGuest(inviteGuestInput, userId);
+			await eventService.inviteGuest(hostInviteGuestInput, userId);
 			const result = await eventService.getGuestsByEvent(event.id);
 
 			expect(result).toEqual([{
 				id: userId,
 				userId: userId,
 				eventId: event.id,
-				confirmationStatus: 'HOST',
+				confirmationStatus: 'ATTENDING',
+                isHost: true
 			}, {
 				id: guestId,
 				userId: guestId,
 				eventId: event.id,
 				confirmationStatus: 'PENDING',
+                isHost: true
 			}]);
 		})
 	})

--- a/test/event/util/event.repository.util.ts
+++ b/test/event/util/event.repository.util.ts
@@ -26,7 +26,8 @@ export class EventRepositoryUtil implements IEventRepository{
 			id: this.guestId++,
 			userId: 1,
 			eventId: this.id++,
-			confirmationStatus: 'HOST',
+			confirmationStatus: 'ATTENDING',
+            isHost: true
 		};
 		this.events.push(event);
 		this.guests.push(guest);
@@ -60,8 +61,7 @@ export class EventRepositoryUtil implements IEventRepository{
 		let counter = 0;
 		for(let i=0; i<this.guests.length; i++){
 			if (this.guests[i].eventId === id &&
-				(this.guests[i].confirmationStatus === 'ATTENDING' ||
-					this.guests[i].confirmationStatus === 'HOST')) counter++;
+				(this.guests[i].confirmationStatus === 'ATTENDING')) counter++;
 		}
 		return Promise.resolve(counter);
 	}
@@ -110,7 +110,7 @@ export class EventRepositoryUtil implements IEventRepository{
 
 	getHostGuest(userId: number, eventId: number): Promise<Guest> {
 		for (const guest of this.guests) {
-			if (guest.eventId === eventId && guest.userId === userId && guest.confirmationStatus === 'HOST') return Promise.resolve(guest);
+			if (guest.eventId === eventId && guest.userId === userId && guest.isHost === true) return Promise.resolve(guest);
 		}
 		return Promise.resolve(undefined);
 	}
@@ -120,6 +120,7 @@ export class EventRepositoryUtil implements IEventRepository{
 		userId: number;
 		eventId: number;
 		confirmationStatus: $Enums.confirmationStatus
+        isHost: boolean
 	}> {
 		for (const guest of this.guests) {
 			if (guest.id === guestId) {
@@ -128,7 +129,8 @@ export class EventRepositoryUtil implements IEventRepository{
 					id: guest.id,
 					userId: guest.userId,
 					eventId: guest.eventId,
-					confirmationStatus: guest.confirmationStatus
+					confirmationStatus: guest.confirmationStatus,
+                    isHost: guest.isHost
 				});
 			}
 		}
@@ -156,6 +158,7 @@ export class EventRepositoryUtil implements IEventRepository{
 		userId: number;
 		eventId: number;
 		confirmationStatus: $Enums.confirmationStatus
+        isHost: boolean
 	}> {
 		for (const guest of this.guests) {
 			if (guest.id === guestId) return Promise.resolve({
@@ -163,6 +166,7 @@ export class EventRepositoryUtil implements IEventRepository{
 				userId: guest.userId,
 				eventId: guest.eventId,
 				confirmationStatus: guest.confirmationStatus,
+                isHost: guest.isHost
 			});
 		}
 	}
@@ -172,6 +176,7 @@ export class EventRepositoryUtil implements IEventRepository{
 		userId: number;
 		eventId: number;
 		confirmationStatus: $Enums.confirmationStatus
+        isHost: boolean
 	}[]> {
 		const result = [];
 		for (const guest of this.guests) {
@@ -185,6 +190,7 @@ export class EventRepositoryUtil implements IEventRepository{
 		userId: number;
 		eventId: number;
 		confirmationStatus: $Enums.confirmationStatus
+        isHost: boolean
 	}[]> {
 		const result = [];
 		for (const guest of this.guests) {
@@ -193,17 +199,19 @@ export class EventRepositoryUtil implements IEventRepository{
 		return Promise.resolve(result);
 	}
 
-	inviteGuest(eventId: number, invitedId: number): Promise<{
+	inviteGuest(eventId: number, invitedId: number, isHost: boolean): Promise<{
 		id: number;
 		userId: number;
 		eventId: number;
 		confirmationStatus: $Enums.confirmationStatus
+        isHost: boolean
 	}> {
 		const guest : Guest = {
 			id: this.guestId++,
 			userId: invitedId,
 			eventId: eventId,
 			confirmationStatus: 'PENDING',
+            isHost: isHost
 		}
 		this.guests.push(guest);
 		return Promise.resolve(guest);


### PR DESCRIPTION
Invites now have an isHost boolean to indicate if the invited user is a host or not, apart form the usual ConfirmationStatus enum. Also HOST was removed from ConfirmationStatus.